### PR TITLE
Update tester

### DIFF
--- a/src/HidApi.Net.Tester/Verifier/Osx.cs
+++ b/src/HidApi.Net.Tester/Verifier/Osx.cs
@@ -15,7 +15,7 @@ public class Osx : HidApiVerifier
 
     public bool VerifyWCharPointer()
     {
-        const string Expected = "hid_error is not implemented yet";
+        const string Expected = "Success";
         unsafe
         {
             var ptr = NativeMethods.Error(DeviceSafeHandle.Null);

--- a/src/HidApi.Net.Tester/Verifier/Windows.cs
+++ b/src/HidApi.Net.Tester/Verifier/Windows.cs
@@ -16,7 +16,7 @@ public class Windows : HidApiVerifier
     public bool VerifyWCharPointer()
     {
         string? result;
-        const string Expected = "hid_error for global errors is not implemented yet";
+        const string Expected = "Success";
         unsafe
         {
             var ptr = NativeMethods.Error(DeviceSafeHandle.Null);


### PR DESCRIPTION
- Osx does support error messages since version 0.13. As homebrew now has this version available we can check for "Success" as a standard return value.
- Windows does support error messages since version 0.13. As MSYS 2 now has this version available we can check for "Success" as standard return value.