### PR TITLE
Address CA1816: Call GC.SuppressFinalize correctly

### DIFF
--- a/src/HidApi.Net/Device.cs
+++ b/src/HidApi.Net/Device.cs
@@ -4,7 +4,7 @@ namespace HidApi;
 /// Represents a HID device.
 /// </summary>
 /// <remarks>Call Dispose to free all unmanaged resources.</remarks>
-public class Device : IDisposable
+public sealed class Device : IDisposable
 {
     private readonly DeviceSafeHandle handle;
 


### PR DESCRIPTION
Not sure the potential issue actually applies to .Net Core. But this silences the warning.