### PR TITLE
Address CA1419

### DIFF
--- a/src/HidApi.Net/Internal/DeviceSafeHandle.cs
+++ b/src/HidApi.Net/Internal/DeviceSafeHandle.cs
@@ -7,7 +7,7 @@ internal class DeviceSafeHandle : SafeHandle
     public static readonly DeviceSafeHandle Null = new();
     public override bool IsInvalid => handle == IntPtr.Zero;
 
-    private DeviceSafeHandle() : base(IntPtr.Zero, true) { }
+    internal DeviceSafeHandle() : base(IntPtr.Zero, true) { }
 
     protected override bool ReleaseHandle()
     {


### PR DESCRIPTION
Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'