### PR TITLE
Specify TargetFramework .NET 6.0 for HidApi.Net project

### DIFF
--- a/src/HidApi.Net/HidApi.Net.csproj
+++ b/src/HidApi.Net/HidApi.Net.csproj
@@ -1,5 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <AnalysisLevel>6.0-recommended</AnalysisLevel>
+    <EnableNETAnalyzers>True</EnableNETAnalyzers>
+    
     <VersionPrefix>0.4.0</VersionPrefix>
 
     <RootNamespace>HidApi</RootNamespace>


### PR DESCRIPTION
Since you are using records, I suggest specifying TargetFramework .NET 6.0 or 8.0. I have tested with .NET 8.0, works fine.