### PR TITLE
Don't reference SourceLink for net8.0

### DIFF
--- a/src/HidApi.Net/HidApi.Net.csproj
+++ b/src/HidApi.Net/HidApi.Net.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" Condition="'$(TargetFramework)' == 'net6.0' or '$(TargetFramework)' == 'net7.0'"/>
     <InternalsVisibleTo Include="$(AssemblyName).Tester" />
     <InternalsVisibleTo Include="$(AssemblyName).Tests" />
     <None Include="../../readme.md" Pack="true" PackagePath="/" />


### PR DESCRIPTION
Sourcelink is included in the SDK starting with net8.0

Fixes: #71