### PR TITLE
Add Read overloads for passing in buffer

### DIFF
--- a/src/HidApi.Net/Device.cs
+++ b/src/HidApi.Net/Device.cs
@@ -68,44 +68,34 @@ public sealed class Device : IDisposable
     /// <summary>
     /// Returns an input report.
     /// </summary>
-    /// <param name="maxLength">Max length of the expected data. The value can be greater than the actual report.</param>
+    /// <param name="buffer">Buffer to write the data into</param>
     /// <param name="milliseconds">timeout in milliseconds. -1 for blocking mode.</param>
-    /// <returns>The received data of the HID device. If the timeout is exceeded an empty result is returned.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Raised if maxlength is smaller than 0</exception>
+    /// <returns>The length of the received data in bytes. If the timeout is exceeded 0 is returned.</returns>
     /// <exception cref="HidException">Raised on failure</exception>
-    public ReadOnlySpan<byte> ReadTimeout(int maxLength, int milliseconds)
+    public int ReadTimeout(Span<byte> buffer, int milliseconds)
     {
-        if (maxLength < 0)
-            throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, "Please provide a positive value");
-
-        ReadOnlySpan<byte> data = new byte[maxLength];
-        var result = NativeMethods.ReadTimeOut(handle, data, milliseconds);
+        var result = NativeMethods.ReadTimeOut(handle, buffer, milliseconds);
 
         if (result == -1)
             HidException.Throw(handle);
 
-        return data[..result];
+        return result;
     }
 
     /// <summary>
     /// Returns an input report.
     /// </summary>
-    /// <param name="maxLength">Max length of the expected data. The value can be greater than the actual report.</param>
-    /// <returns>The received data of the HID device. If non-blocking mode is enabled and no data is available an empty result will be returned.</returns>
-    /// <exception cref="ArgumentOutOfRangeException">Raised if maxlength is smaller than 0</exception>
+    /// <param name="buffer">Buffer to write the data into</param>
+    /// <returns>The length of the received data in bytes. If non-blocking mode is enabled and no data is available 0 will be returned.</returns>
     /// <exception cref="HidException">Raised on failure</exception>
-    public ReadOnlySpan<byte> Read(int maxLength)
+    public int Read(Span<byte> buffer)
     {
-        if (maxLength < 0)
-            throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, "Please provide a positive value");
-
-        ReadOnlySpan<byte> data = new byte[maxLength];
-        var result = NativeMethods.Read(handle, data);
+        var result = NativeMethods.Read(handle, buffer);
 
         if (result == -1)
             HidException.Throw(handle);
 
-        return data[..result];
+        return result;
     }
 
     /// <summary>

--- a/src/HidApi.Net/Internal/NativeMethods.cs
+++ b/src/HidApi.Net/Internal/NativeMethods.cs
@@ -42,12 +42,12 @@ internal static partial class NativeMethods
         return Write(device, ref MemoryMarshal.GetReference(data), (nuint) data.Length);
     }
 
-    public static int ReadTimeOut(DeviceSafeHandle device, ReadOnlySpan<byte> data, int milliseconds)
+    public static int ReadTimeOut(DeviceSafeHandle device, Span<byte> data, int milliseconds)
     {
         return ReadTimeOut(device, ref MemoryMarshal.GetReference(data), (nuint) data.Length, milliseconds);
     }
 
-    public static int Read(DeviceSafeHandle device, ReadOnlySpan<byte> data)
+    public static int Read(DeviceSafeHandle device, Span<byte> data)
     {
         return Read(device, ref MemoryMarshal.GetReference(data), (nuint) data.Length);
     }


### PR DESCRIPTION
Implements #101

Warning: I did tested this only briefly (with a short bit of temporary code in `HidApi.Tester`). Can you recommend a good way to test it beyond that?

The method signatures had to slightly change compared to what we last discussed in the issue:

```csharp
public interface IDevice {
    int Read(Span<byte> buffer);
    int ReadTimeout(Span<byte> buffer, int milliseconds);

    // removed based on discussion
    // ReadOnlySpan<byte> Read(int maxLength);
    // ReadOnlySpan<byte> ReadTimeout(int maxLength, int milliseconds);
}
```

As the `Read` might not fill the whole buffer, the new overloads have to return the read length. I believe this is another good reason to leave the previous signatures intact, as they prevent this mistake.