### PR TITLE
Fix internal methods using ReadOnlySpans as writable

### DIFF
--- a/src/HidApi.Net/Device.cs
+++ b/src/HidApi.Net/Device.cs
@@ -138,15 +138,14 @@ public sealed class Device : IDisposable
         if (maxLength < 1)
             throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, "Please provide a value greater than 1");
 
-        var data = new byte[maxLength];
+        var data = new Span<byte>(new byte[maxLength]);
         data[0] = reportId;
-        ReadOnlySpan<byte> spanData = data;
-        var result = NativeMethods.GetFeatureReport(handle, spanData);
+        var result = NativeMethods.GetFeatureReport(handle, data);
 
         if (result == -1)
             HidException.Throw(handle);
 
-        return spanData[..result];
+        return data[..result];
     }
 
     /// <summary>
@@ -163,15 +162,14 @@ public sealed class Device : IDisposable
         if (maxLength < 1)
             throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, "Please provide a value greater than 1");
 
-        var data = new byte[maxLength];
+        var data = new Span<byte>(new byte[maxLength]);
         data[0] = reportId;
-        ReadOnlySpan<byte> spanData = data;
-        var result = NativeMethods.GetInputReport(handle, spanData);
+        var result = NativeMethods.GetInputReport(handle, data);
 
         if (result == -1)
             HidException.Throw(handle);
 
-        return spanData[..result];
+        return data[..result];
     }
 
     /// <summary>
@@ -303,14 +301,13 @@ public sealed class Device : IDisposable
         if (bufSize < 0)
             throw new ArgumentOutOfRangeException(nameof(bufSize), bufSize, "Please provide a positive value");
 
-        var data = new byte[bufSize];
-        ReadOnlySpan<byte> spanData = data;
-        var result = NativeMethods.GetReportDescriptor(handle, spanData);
+        var data = new Span<byte>(new byte[bufSize]);
+        var result = NativeMethods.GetReportDescriptor(handle, data);
 
         if (result == -1)
             HidException.Throw(handle);
 
-        return spanData[..result];
+        return data[..result];
     }
 
     /// <summary>

--- a/src/HidApi.Net/Internal/NativeMethods.cs
+++ b/src/HidApi.Net/Internal/NativeMethods.cs
@@ -77,17 +77,17 @@ internal static partial class NativeMethods
         return SendFeatureReport(device, ref MemoryMarshal.GetReference(data), (nuint) data.Length);
     }
 
-    public static int GetFeatureReport(DeviceSafeHandle device, ReadOnlySpan<byte> data)
+    public static int GetFeatureReport(DeviceSafeHandle device, Span<byte> data)
     {
         return GetFeatureReport(device, ref MemoryMarshal.GetReference(data), (nuint) data.Length);
     }
 
-    public static int GetInputReport(DeviceSafeHandle device, ReadOnlySpan<byte> data)
+    public static int GetInputReport(DeviceSafeHandle device, Span<byte> data)
     {
         return GetInputReport(device, ref MemoryMarshal.GetReference(data), (nuint) data.Length);
     }
 
-    public static int GetReportDescriptor(DeviceSafeHandle device, ReadOnlySpan<byte> buf)
+    public static int GetReportDescriptor(DeviceSafeHandle device, Span<byte> buf)
     {
         return GetReportDescriptor(device, ref MemoryMarshal.GetReference(buf), (nuint) buf.Length);
     }


### PR DESCRIPTION
(fixes #103)

I've only changed the methods that read directly into `ReadOnlySpan`s. It might be worth it to update the ones that read into `WCharTString`s if the library is adapted as well - I'll take a look at the implementation in the coming days, it sounds really interesting! :)

The change is implemented as discussed, but my IDE (Jetbrains Rider) suggests using the object initializer syntax for setting the report ID as well. This would mean there are 3 possible implementations (using the example of `GetFeatureReport` again):

**Option 1** (currently implemented):

```csharp
public ReadOnlySpan<byte> GetFeatureReport(byte reportId, int maxLength)
{
    if (maxLength < 1)
        throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, "Please provide a value greater than 1");

    var data = new Span<byte>(new byte[maxLength]);
    data[0] = reportId;
    var result = NativeMethods.GetFeatureReport(handle, data);

    if (result == -1)
        HidException.Throw(handle);

    return data[..result];
}
```

**Option 2** (with object initializer):

```csharp
public ReadOnlySpan<byte> GetFeatureReport(byte reportId, int maxLength)
{
    if (maxLength < 1)
        throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, "Please provide a value greater than 1");

    var data = new Span<byte>(new byte[maxLength]) { [0] = reportId };
    var result = NativeMethods.GetFeatureReport(handle, data);

    if (result == -1)
        HidException.Throw(handle);

    return data[..result];
}
```

**Option 3** (implicit conversion):

```csharp
public ReadOnlySpan<byte> GetFeatureReport(byte reportId, int maxLength)
{
    if (maxLength < 1)
        throw new ArgumentOutOfRangeException(nameof(maxLength), maxLength, "Please provide a value greater than 1");

    Span<byte> data = new byte[maxLength];
    data[0] = reportId;
    var result = NativeMethods.GetFeatureReport(handle, data);

    if (result == -1)
        HidException.Throw(handle);

    return data[..result];
}
```

Which do you prefer? I think all options are readable, though 2 reads the worst IMO (and I'm not sure it's correctly formatted, it's what my IDE suggested).