### PR TITLE
GC Free implementation of Enumerate

### DIFF
--- a/src/HidApi.Net/Hid.cs
+++ b/src/HidApi.Net/Hid.cs
@@ -33,14 +33,14 @@ public static class Hid
     }
 
     /// <summary>
-    /// Enuemrate available HID devices.
+    /// Enumerate available HID devices.
     /// </summary>
     /// <param name="vendorId">Vendor id of devices to open or 0 to match any vendor</param>
     /// <param name="productId">Product id of devices to open or 0 to match any product</param>
     /// <returns>Enumerable of <seealso cref="DeviceInfo"/></returns>
-    public static IEnumerable<DeviceInfo> Enumerate(ushort vendorId = 0, ushort productId = 0)
+    public static HidEnumerator Enumerate(ushort vendorId = 0, ushort productId = 0)
     {
-        return Enumerator.Enumerate(vendorId, productId);
+        return new HidEnumerator(vendorId, productId);
     }
 
     /// <summary>


### PR DESCRIPTION
The existing implementation filled a list, and then returned an enumerator to that.

The list itself is heap allocated, any required resizing will also increase GC pressure.

The new implementation implements an enumerator directly on the underlying native Enumerate methods, preventing any GC from happening. The Hid api also returns the new HidEnumerator type directly rather than an interface to prevent boxing.